### PR TITLE
fix(aff): consult AF aliases for numeric flag types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SIMPLIFIEDTRIPLE`).
 * `NOSPLITSUGS` is now honored: the suggester no longer proposes splitting a word
   into two when the dictionary sets this flag.
+* Fixed flag decoding for dictionaries that combine `FLAG num` with an `AF`
+  alias table. A flag field is now resolved as an alias index rather than
+  decoded as a literal numeric flag, so alias references expand correctly
+  (matching Hunspell and Nuspell). Previously affected dictionaries such as
+  Korean, whose suffix rules are referenced through `AF` aliases, reported
+  every suffixed word as misspelled.
 
 ### Performance
 

--- a/src/aff/parser.rs
+++ b/src/aff/parser.rs
@@ -1185,8 +1185,11 @@ fn decode_flagset(
     flag_type: FlagType,
     aliases: &[FlagSet],
 ) -> core::result::Result<FlagSet, ParseFlagError> {
-    // Fast lane for numeric flag-types and empty aliases.
-    if matches!(flag_type, FlagType::Numeric) || aliases.is_empty() {
+    // Fast lane when there are no flag aliases. An `AF` alias table takes
+    // priority over the flag type: a flagset field is decoded as a 1-based alias
+    // index even under `FLAG num`. Hunspell:
+    // <https://github.com/hunspell/hunspell/blob/2969be996acad84b91ab3875b1816636fe61a40e/src/hunspell/hashmgr.cxx#L652-L660>
+    if aliases.is_empty() {
         return parse_flags_from_str(flag_type, input);
     }
 
@@ -1851,33 +1854,56 @@ mod test {
 
     #[test]
     fn decode_flagset_test() {
-        let aliases = &[flagset![1], flagset![2], flagset![3, 4]];
+        // Alias values differ from their indices so resolving an index is
+        // distinguishable from decoding a literal flag.
+        let aliases = &[flagset![100], flagset![200, 300]];
 
+        // With an alias table a flagset field is a 1-based alias index.
         // NOTE: 1-indexing.
         assert_eq!(
-            flagset![1],
+            flagset![100],
             decode_flagset("1", FlagType::default(), aliases).unwrap()
         );
         assert_eq!(
-            flagset![2],
+            flagset![200, 300],
             decode_flagset("2", FlagType::default(), aliases).unwrap()
         );
+
+        // The alias table takes priority over the flag type: `FLAG num` resolves
+        // the index rather than decoding the literal flag {1}.
         assert_eq!(
-            flagset![3, 4],
+            flagset![100],
+            decode_flagset("1", FlagType::Numeric, aliases).unwrap()
+        );
+        assert_eq!(
+            flagset![200, 300],
+            decode_flagset("2", FlagType::Numeric, aliases).unwrap()
+        );
+
+        // An out-of-range index falls back to decoding a literal flag.
+        assert_eq!(
+            flagset!['3' as u16],
             decode_flagset("3", FlagType::default(), aliases).unwrap()
         );
+        assert_eq!(
+            flagset![3],
+            decode_flagset("3", FlagType::Numeric, aliases).unwrap()
+        );
+
+        // A non-integer field can't be an index, so it's decoded literally.
         assert_eq!(
             flagset!['a' as u16],
             decode_flagset("a", FlagType::default(), aliases).unwrap()
         );
 
-        assert_eq!(
-            flagset![1],
-            decode_flagset("1", FlagType::Numeric, aliases).unwrap()
-        );
+        // Without an alias table the field is always decoded literally.
         assert_eq!(
             flagset!['1' as u16],
             decode_flagset("1", FlagType::default(), &[]).unwrap()
+        );
+        assert_eq!(
+            flagset![1],
+            decode_flagset("1", FlagType::Numeric, &[]).unwrap()
         );
     }
 


### PR DESCRIPTION
`decode_flagset` has a fast lane that decodes a flag field as a literal flag whenever `FLAG num` is set, without consulting the `AF` alias table. So for a dictionary that uses both `FLAG num` and `AF`, an entry like `word/1` ends up with the literal flag `1` instead of expanding alias `#1`, and any affix rule referenced through an alias fails to match.

An `AF` table should take priority over the flag type. Hunspell resolves the field as an alias index whenever the table is non-empty and only decodes a literal flag when there is no table: https://github.com/hunspell/hunspell/blob/2969be996acad84b91ab3875b1816636fe61a40e/src/hunspell/hashmgr.cxx#L652-L660. Nuspell does the same, and `hunspell.5` doesn't specify the precedence.

The fix drops the `FlagType::Numeric` short-circuit so the fast lane only applies when there are no aliases. The existing alias-index lookup then covers numeric dictionaries too, and out-of-range indices or non-integer fields still fall through to the literal decode unchanged.

I ran into this with the Korean dictionary: it uses `FLAG num` with an `AF` table, and its suffix (josa) rules are all referenced through aliases, so with the fast lane every suffixed word was reported as misspelled.

I extended `decode_flagset_test` to cover alias resolution under `FLAG num` along with the out-of-range and no-alias-table fallbacks.
